### PR TITLE
Correct format of generated Date: header

### DIFF
--- a/box_data_archiver
+++ b/box_data_archiver
@@ -44,7 +44,7 @@ fi
 
 REPORT=`mktemp -t box_usage_report.XXXXXX`
 $data_cat_cmd | python "${box_utils_dir}/user_report.py" > $REPORT
-echo -ne "Date: `date`\nFrom: ${deliver_report_from}\nTo: ${deliver_report_to}\nSubject: Box User Report `date +%Y-%m-%d`\n\n" | cat - ${REPORT} | sendmail -oi -t
+echo -ne "Date: `date -R`\nFrom: ${deliver_report_from}\nTo: ${deliver_report_to}\nSubject: Box User Report `date +%Y-%m-%d`\n\n" | cat - ${REPORT} | sendmail -oi -t
 
 $data_compress_cmd
 rm $REPORT


### PR DESCRIPTION
RFC 5322 requires dates in email headers to adhere to a specific format, which is not the same as the default output of date(1). 'date -R' is a somewhat portable way of getting a correctly formatted date.
